### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/daemon11.py
+++ b/daemon11.py
@@ -133,5 +133,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon12.py
+++ b/daemon12.py
@@ -128,5 +128,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon13.py
+++ b/daemon13.py
@@ -138,5 +138,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon14.py
+++ b/daemon14.py
@@ -142,5 +142,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon15.py
+++ b/daemon15.py
@@ -148,5 +148,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon16.py
+++ b/daemon16.py
@@ -123,5 +123,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon17.py
+++ b/daemon17.py
@@ -203,5 +203,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon23.py
+++ b/daemon23.py
@@ -251,5 +251,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon98.py
+++ b/daemon98.py
@@ -132,5 +132,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon99.py
+++ b/daemon99.py
@@ -158,5 +158,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/libdaemon.py
+++ b/libdaemon.py
@@ -33,7 +33,7 @@ class Daemon:
         # exit first parent
         sys.exit(0)
     except OSError, e:
-      sys.stderr.write("fork no.1 failed: %d (%s)\n" % (e.errno, e.strerror))
+      sys.stderr.write("fork no.1 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
       sys.exit(1)
 
     # decouple from parent environment
@@ -48,7 +48,7 @@ class Daemon:
         # exit from second parent
         sys.exit(0)
     except OSError, e:
-      sys.stderr.write("fork no.2 failed: %d (%s)\n" % (e.errno, e.strerror))
+      sys.stderr.write("fork no.2 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
       sys.exit(1)
 
     # redirect standard file descriptors
@@ -64,7 +64,7 @@ class Daemon:
     # write pidfile
     atexit.register(self.delpid)
     pid = str(os.getpid())
-    file(self.pidfile,'w+').write("%s\n" % pid)
+    file(self.pidfile,'w+').write("{0!s}\n".format(pid))
 
   def delpid(self):
     os.remove(self.pidfile)

--- a/sqlrand.py
+++ b/sqlrand.py
@@ -128,5 +128,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/testgraphs.py
+++ b/testgraphs.py
@@ -18,7 +18,7 @@ def taildata():
 
   fout = file('/tmp/taildata.txt','w')
   for c in F:
-    fout.write("%s" % (c) )
+    fout.write("{0!s}".format((c)) )
   fout.close()
 
 def graphs():


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Mausy5043:raspdiagd?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Mausy5043:raspdiagd?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
